### PR TITLE
Use environment variable for GameB path

### DIFF
--- a/CopyAssets.bat
+++ b/CopyAssets.bat
@@ -1,2 +1,2 @@
-del C:\Users\ryanr\source\repos\GameB\x64\Debug\Assets\ /Q
-xcopy C:\Users\ryanr\source\repos\GameB\Assets C:\Users\ryanr\source\repos\GameB\x64\Debug\Assets /i
+del %GAMEBDIR%\x64\Debug\Assets\ /Q
+xcopy %GAMEBDIR%\Assets %GAMEBDIR%\x64\Debug\Assets /i

--- a/GameB.vcxproj
+++ b/GameB.vcxproj
@@ -136,7 +136,7 @@
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
     <PostBuildEvent>
-      <Command>C:\Users\ryanr\source\repos\GameB\CopyAssets.bat</Command>
+      <Command>%GAMEBDIR%\CopyAssets.bat</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -184,7 +184,7 @@
       <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
     </Manifest>
     <PostBuildEvent>
-      <Command>C:\Users\ryanr\source\repos\GameB\CopyAssets.bat</Command>
+      <Command>%GAMEBDIR%\CopyAssets.bat</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Currently, specific paths are hard-coded which make compilation impossible without making changes to committed files.

I propose using an environment variable, GAMEBDIR so that the repo can be put into any directory.

This change allows clean compilation for me.

Additional considerations: Perhaps we need to add this as a setup instruction to the Readme, or some other appropriate location.
