### PR TITLE
Fix Warning C4133, incompatiple types from 'PIXEL32 *' to '__m128i *'

### DIFF
--- a/Main.c
+++ b/Main.c
@@ -1597,7 +1597,7 @@ __forceinline void ClearScreen(_In_ __m128i* Color)
 {
     for (int x = 0; x < GAME_RES_WIDTH * GAME_RES_HEIGHT; x += 4)
     {
-        _mm_store_si128((PIXEL32*)gBackBuffer.Memory + x, *Color);        
+        _mm_store_si128((__m128i *)((PIXEL32*)gBackBuffer.Memory + x), *Color);
     }
 }
 #else


### PR DESCRIPTION
Just fixing the annoying compile warning with a cast and parenthesis.