### PR TITLE
Added prototype procedure DrawWindowThick for review.

### DIFF
--- a/CharacterNamingScreen.c
+++ b/CharacterNamingScreen.c
@@ -187,7 +187,7 @@ void DrawCharacterNaming(void)
 
     ApplyFadeIn(LocalFrameCounter, COLOR_NES_WHITE, &TextColor, &BrightnessAdjustment);
 
-    DrawWindow(108, 11, 166, 18, &TextColor, NULL, &COLOR_NES_BLACK, WINDOW_FLAG_BORDERED | WINDOW_FLAG_SHADOW);
+    DrawWindowThick(108, 11, 166, 18, &TextColor, NULL, &COLOR_NES_BLACK, WINDOW_FLAG_BORDERED | WINDOW_FLAG_SHADOW | WINDOW_FLAG_ROUNDED_CORNERS);
 
     DrawWindow(108, 105, 166, 60, &TextColor, NULL, &COLOR_NES_BLACK, WINDOW_FLAG_BORDERED | WINDOW_FLAG_SHADOW);
 

--- a/Main.c
+++ b/Main.c
@@ -18,7 +18,7 @@
 // miniz by Rich Geldreich <richgel99@gmail.com> is public domain (or possibly MIT licensed) and a copy of its license can be found in the miniz.c file.
 
 
-// "Don't build software. Create an endless yearning for C." -- Antoine de Saint—Exupery
+// "Don't build software. Create an endless yearning for C." -- Antoine de Saintï¿½Exupery
 //
 // --- TODO ---
 // Move extern globals to their own header file?
@@ -175,7 +175,7 @@ int32_t gFontCharacterPixelOffset[] = {
         62,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,82,79,83,63,93,
     //  .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. ..
         93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,
-    //  .. .. .. .. .. .. .. .. .. .. .. «  .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. »  .. .. .. ..
+    //  .. .. .. .. .. .. .. .. .. .. .. ï¿½  .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. ï¿½  .. .. .. ..
         93,93,93,93,93,93,93,93,93,93,93,96,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,95,93,93,93,93,
     //  .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. ..
         93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,93,
@@ -1351,14 +1351,14 @@ void Blit32BppBitmapToBuffer(_In_ GAMEBITMAP* GameBitmap, _In_ int16_t x, _In_ i
 			// If unable to guarantee 32-byte alignment, use _mm256_loadu_si256 instead.
             BitmapOctoPixel = _mm256_load_si256((const __m256i*)((PIXEL32*)GameBitmap->Memory + BitmapOffset));
             //        AARRGGBBAARRGGBB-AARRGGBBAARRGGBB-AARRGGBBAARRGGBB-AARRGGBBAARRGGBB
-            // YMM0 = FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1
+            // YMM0ï¿½=ï¿½FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1
 
             // Blow the 256-bit vector apart into two separate 256-bit vectors Half1 and Half2, 
             // each containing 4 pixels, where each pixel is now 16 bits instead of 8.            
 
             __m256i Half1 = _mm256_cvtepu8_epi16(_mm256_extracti128_si256(BitmapOctoPixel, 0));
             //        AAAARRRRGGGGBBBB-AAAARRRRGGGGBBBB-AAAARRRRGGGGBBBB-AAAARRRRGGGGBBBB
-            // YMM0 = 00FF005B006E00E1-00FF005B006E00E1-00FF005B006E00E1-00FF005B006E00E1
+            // YMM0ï¿½=ï¿½00FF005B006E00E1-00FF005B006E00E1-00FF005B006E00E1-00FF005B006E00E1
 
             // Add the brightness adjustment to each 16-bit element, except alpha.
             Half1 = _mm256_add_epi16(Half1, _mm256_set_epi16(
@@ -1486,18 +1486,18 @@ void BlitBackgroundToBuffer(_In_ GAMEBITMAP* GameBitmap, _In_ int16_t Brightness
             // Load 256 bits (8 pixels) from memory into register YMMx
             BitmapOctoPixel = _mm256_load_si256((const __m256i*)((PIXEL32*)GameBitmap->Memory + BitmapOffset));
             //        AARRGGBBAARRGGBB-AARRGGBBAARRGGBB-AARRGGBBAARRGGBB-AARRGGBBAARRGGBB
-            // YMM0 = FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1
+            // YMM0ï¿½=ï¿½FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1-FF5B6EE1FF5B6EE1
 
             // Blow the 256-bit vector apart into two separate 256-bit vectors Half1 and Half2, 
             // each containing 4 pixels, where each pixel is now 16 bits instead of 8.            
 
             __m256i Half1 = _mm256_cvtepu8_epi16(_mm256_extracti128_si256(BitmapOctoPixel, 0));
             //        AAAARRRRGGGGBBBB-AAAARRRRGGGGBBBB-AAAARRRRGGGGBBBB-AAAARRRRGGGGBBBB
-            // YMM0 = 00FF005B006E00E1-00FF005B006E00E1-00FF005B006E00E1-00FF005B006E00E1
+            // YMM0ï¿½=ï¿½00FF005B006E00E1-00FF005B006E00E1-00FF005B006E00E1-00FF005B006E00E1
 
             // Add the brightness adjustment to each 16-bit element
             Half1 = _mm256_add_epi16(Half1, _mm256_set1_epi16(BrightnessAdjustment));
-            // YMM0 = 0000FF5CFF6FFFE2-0000FF5CFF6FFFE2-0000FF5CFF6FFFE2-0000FF5CFF6FFFE2
+            // YMM0ï¿½=ï¿½0000FF5CFF6FFFE2-0000FF5CFF6FFFE2-0000FF5CFF6FFFE2-0000FF5CFF6FFFE2
 
             // Do the same for Half2 that we just did for Half1.
             __m256i Half2 = _mm256_cvtepu8_epi16(_mm256_extracti128_si256(BitmapOctoPixel, 1));
@@ -2941,6 +2941,7 @@ Exit:
 // Either the BORDERED or the OPAQUE flag needs to be set, or both, or else the window would just be
 // transparent and invisible. The window border will cut into the inside of the window area.
 // TODO: Implement a WINDOW_FLAG_ROUNDED_CORNERS?
+
 void DrawWindow(
     _In_opt_ uint16_t x,
     _In_opt_ uint16_t y,
@@ -3033,6 +3034,169 @@ void DrawWindow(
         {
             MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * Row) + Width;
 
+            memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset, ShadowColor, sizeof(PIXEL32));
+        }
+    }
+}
+
+// Prototype procedure for testing/review
+// DrawWindow procedure that implements WINDOW_FLAG_ROUNDED_CORNERS
+// The windows are drawn with a border of 2 pixels wide.
+void DrawWindowThick(
+    _In_opt_ uint16_t x,
+    _In_opt_ uint16_t y,
+    _In_ int16_t Width,
+    _In_ int16_t Height,
+    _In_opt_ PIXEL32* BorderColor,
+    _In_opt_ PIXEL32* BackgroundColor,
+    _In_opt_ PIXEL32* ShadowColor,
+    _In_ DWORD Flags)
+{
+    if (Flags & WINDOW_FLAG_HORIZONTALLY_CENTERED)
+    {
+        x = (GAME_RES_WIDTH / 2) - (Width / 2);
+    }
+
+    if (Flags & WINDOW_FLAG_VERTICALLY_CENTERED)
+    {
+        y = (GAME_RES_HEIGHT / 2) - (Height / 2);
+    }
+
+    ASSERT((x + Width <= GAME_RES_WIDTH) && (y + Height <= GAME_RES_HEIGHT), "Window is off the screen!");
+    
+    ASSERT((Flags & WINDOW_FLAG_BORDERED) || (Flags & WINDOW_FLAG_OPAQUE), "Window must have either the BORDERED or the OPAQUE flags (or both) set!");
+
+    int32_t StartingScreenPixel = ((GAME_RES_WIDTH * GAME_RES_HEIGHT) - GAME_RES_WIDTH) - (GAME_RES_WIDTH * y) + x;
+
+    if (Flags & WINDOW_FLAG_OPAQUE)
+    {
+        ASSERT(BackgroundColor != NULL, "WINDOW_FLAG_OPAQUE is set but BackgroundColor is NULL!");
+
+        for (int Row = 0; Row < Height; Row++)
+        {
+            int MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * Row);
+
+            for (int Pixel = 0; Pixel < Width; Pixel++)
+            {
+                memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset + Pixel, BackgroundColor, sizeof(PIXEL32));
+            }
+        }
+    }
+
+    if (Flags & WINDOW_FLAG_BORDERED)
+    {
+        ASSERT(BorderColor != NULL, "WINDOW_FLAG_BORDERED is set but BorderColor is NULL!");
+		// Draw the top of the border.
+		int MemoryOffset = StartingScreenPixel;
+
+		// easy solution, we'll make every window 2 pixels thick
+		if( Flags & WINDOW_FLAG_ROUNDED_CORNERS)
+		{
+			for (int Pixel = 1; Pixel < Width-1; Pixel++)
+			{
+				memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset + Pixel, BorderColor, sizeof(PIXEL32));
+			}
+		}
+		else
+		{
+			for (int Pixel = 0; Pixel < Width; Pixel++)
+			{
+				memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset + Pixel, BorderColor, sizeof(PIXEL32));
+			}
+		}
+
+        // draw 2nd line of top
+		MemoryOffset = StartingScreenPixel - GAME_RES_WIDTH;
+		for (int Pixel = 0; Pixel < Width; Pixel++)
+		{
+            memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset + Pixel, BorderColor, sizeof(PIXEL32));
+		}
+
+        // Draw the bottom of the border.
+        MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * (Height - 2));
+        for (int Pixel = 0; Pixel < Width; Pixel++)
+        {
+            memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset + Pixel, BorderColor, sizeof(PIXEL32));
+        }
+        
+        // draw 2nd line of bottom border
+        MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * (Height - 1 ));
+
+        if (Flags & WINDOW_FLAG_ROUNDED_CORNERS)
+        {
+            for (int Pixel = 1; Pixel < Width-1; Pixel++)
+            {
+             memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset + Pixel, BorderColor, sizeof(PIXEL32));
+            }
+        }
+        else
+        {
+            for (int Pixel = 0; Pixel < Width; Pixel++)
+            {
+                memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset + Pixel, BorderColor, sizeof(PIXEL32));
+            }
+        }
+
+        // Draw one pixel on the left side and the right for each row of the border, from the top down.
+        for (int Row = 1; Row < Height - 1; Row++)
+        {
+            MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * Row - 1 );
+
+            memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset, BorderColor, sizeof(PIXEL32));
+
+            MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * Row) + (Width - 2);
+
+            memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset, BorderColor, sizeof(PIXEL32));
+        }
+
+        for (int Row = 1; Row < Height - 1; Row++)
+        {
+            MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * Row );
+
+            memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset, BorderColor, sizeof(PIXEL32));
+
+            MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * Row) + (Width - 1);
+
+            memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset, BorderColor, sizeof(PIXEL32));
+        }
+    }
+
+    // TODO: If a window was placed at the edge of the screen, the shadow effect might attempt
+    // to draw off-screen and crash! i.e. make sure there's room to draw the shadow before attempting!
+    if (Flags & WINDOW_FLAG_SHADOW)
+    {
+        ASSERT(ShadowColor != NULL, "WINDOW_FLAG_SHADOW is set but ShadowColor is NULL!");
+
+        // Draw the bottom of the shadow.
+        int MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * Height);
+
+        int this_width = Width+1;
+        int this_start = 1;
+        int this_row = 1;
+        if( Flags & WINDOW_FLAG_ROUNDED_CORNERS) {
+             this_width--;
+             this_start++;
+             this_row++;
+        }
+
+        for (;this_start < (this_width); this_start++)
+        {
+            memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset + this_start, ShadowColor, sizeof(PIXEL32));
+        }
+
+        // Draw one pixel on the right side for each row of the border, from the top down.
+        
+        for ( ; this_row < Height; this_row++)
+        {
+            MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * this_row) + Width;
+
+            memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset, ShadowColor, sizeof(PIXEL32));
+        }
+
+        // if bordered is on, fix one pixel of the drop shadow
+        if (Flags & WINDOW_FLAG_ROUNDED_CORNERS)
+        {
+            MemoryOffset = StartingScreenPixel - (GAME_RES_WIDTH * (Height - 1)) + (Width - 1);
             memcpy((PIXEL32*)gBackBuffer.Memory + MemoryOffset, ShadowColor, sizeof(PIXEL32));
         }
     }

--- a/Main.h
+++ b/Main.h
@@ -191,9 +191,13 @@
 
 #define COLOR_NES_BLACK	(PIXEL32) { .Bytes = 0xFF000000 }
 
+
 // Some pixel colors that are handy but didn't exist in the NES color palette.
 
 #define COLOR_GRAY_0	(PIXEL32) { .Bytes = 0xFF202020 }
+
+
+
 
 /////////// BEGIN GLOBAL ENUMS /////////////
 
@@ -284,7 +288,9 @@ typedef enum WINDOW_FLAGS
 
 	WINDOW_FLAG_SHADOW = 16,				// 1 << 4, 0b00010000	
 	
-	WINDOW_FLAG_SHAKE = 32					// 1 << 5, 0b00100000
+	WINDOW_FLAG_SHAKE = 32,					// 1 << 5, 0b00100000
+
+	WINDOW_FLAG_ROUNDED_CORNERS = 64		// 1 << 6, 0b01000000
 
 } WINDOW_FLAGS;
 
@@ -719,6 +725,16 @@ DWORD WINAPI AssetLoadingThreadProc(_In_ LPVOID lpParam);
 // transparent and invisible. The window border will cut into the inside of the window area.
 
 void DrawWindow(
+	_In_opt_ uint16_t x,
+	_In_opt_ uint16_t y,
+	_In_ int16_t Width,
+	_In_ int16_t Height,
+	_In_opt_ PIXEL32* BorderColor,
+	_In_opt_ PIXEL32* BackgroundColor,
+	_In_opt_ PIXEL32* ShadowColor,
+	_In_ DWORD Flags);
+
+void DrawWindowThick(
 	_In_opt_ uint16_t x,
 	_In_opt_ uint16_t y,
 	_In_ int16_t Width,


### PR DESCRIPTION
This is a clone of DrawWindow that implements rounded borders and 2-pixel wide border.

I changed one of the calls from CreateNamingScreen.c to use the new DrawWindowThick procedure. I don't know how I feel about the thicker windows. Like to get your opinion on them. If accepted, you can combine with DrawWindow, but I think keeping the ability to create single pixel windows is also valuable.